### PR TITLE
add /searchCategory endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ To get the server running locally:
 | GET    | `/api/items`            | all items      | Returns the list of all items in the db.     |
 | PUT    | `/api/items/:id `       | edit item      | Modify an existing item.                     |
 | DELETE | `/api/items/:id `       | delete item    | Remove item from the db.                     |
-
+| POST   | `/api/items/searchCategory` | filter items| Return items from matching category         |
+| POST   | `/api/items/searchCondition` | filter items| Return items from matching condition         |
+| POST   | `/api/items/searchZipCode` | filter items| Return items from matching zipcode         |
+| POST   | `/api/items/searchCity` | filter items| Return items from matching city         |
 #### User Routes
 
 | Method | Endpoint                | Access Control      | Description                                        |
@@ -126,6 +129,18 @@ To get the server running locally:
 `getAll()` -> Returns all items
 
 `getItemById(itemId)` -> Returns a single item by ID
+
+`updateItem(id, updatedItem)` -> Updates item information by ID
+
+`deleteItem(id)` -> Deletes item by ID
+
+`getItemByCategory(category)` -> Returns items by category
+
+`getItemByCondition(condition)` -> Returns items by condition
+
+`getItemByZipCode(zipcode)` -> Returns items by zipcode
+
+`getItemByCity(city)` -> Returns items by city
 
 <br>
 <br>

--- a/api/server.spec.js
+++ b/api/server.spec.js
@@ -30,7 +30,6 @@ describe('tests for endpoints', () => {
         ]));
   });
 
-  findUser - endpoint;
   describe('findUser', () => {
     it('responds with 200 OK and a user object', () => {
       supertest(server)
@@ -62,6 +61,42 @@ describe('tests for endpoints', () => {
         .get('/api/users/unprotected')
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
+        .expect(200);
+    });
+  });
+
+  describe('searchCategory', () => {
+    it('responds with 200 OK and returns list of users with the specified category', () => {
+      supertest(itemsRouter)
+        .post('/api/items/searchCategory')
+        .send({ category: 'Cameras' })
+        .expect(200);
+    });
+  });
+
+  describe('searchCondition', () => {
+    it('responds with 200 OK and returns a list of users with the specified condition', () => {
+      supertest(itemsRouter)
+        .post('/api/items/searchCondition')
+        .send({ condition: 'Used' })
+        .expect(200);
+    });
+  });
+
+  describe('searchCity', () => {
+    it('responds with 200 OK and returns a list of users with the specified city', () => {
+      supertest(itemsRouter)
+        .post('/api/items/searchCity')
+        .send({ city: 'Philadelphia' })
+        .expect(200);
+    });
+  });
+
+  describe('searchZipCode', () => {
+    it('responds with 200 OK and returns a list of users with the specified zipcode', () => {
+      supertest(itemsRouter)
+        .post('/api/items/searchZipCode')
+        .send({ zipcode: '19099' })
         .expect(200);
     });
   });

--- a/api/server.spec.js
+++ b/api/server.spec.js
@@ -30,7 +30,7 @@ describe('tests for endpoints', () => {
         ]));
   });
 
- findUser-endpoint
+  findUser - endpoint;
   describe('findUser', () => {
     it('responds with 200 OK and a user object', () => {
       supertest(server)
@@ -42,36 +42,27 @@ describe('tests for endpoints', () => {
 
   describe('get all items from db', () => {
     it('responds with the code 200 OK and returns all items from db', () => {
-        supertest(itemsRouter)
-            .get('/api/items')
-            .expect(200);
-    })
+      supertest(itemsRouter)
+        .get('/api/items')
+        .expect(200);
+    });
   });
 
   describe('get all users id', () => {
     it('responds with the code 200 OK and returns a list of all users ids', () => {
-        supertest(usersRouter)
-            .get('/api/users/userIDs')
-            .expect(200);
-    })
+      supertest(usersRouter)
+        .get('/api/users/userIDs')
+        .expect(200);
+    });
   });
 
   describe('get all users router', () => {
     it('responds with the code 200 OK and returns list of all users from unprotected route', () => {
-        supertest(usersRouter)
-          .get('/api/users/unprotected')
-          .set('Accept', 'application/json')
-          .expect('Content-Type', /json/)
-          .expect(200);
-      });
+      supertest(usersRouter)
+        .get('/api/users/unprotected')
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
   });
-
-
 });
-
-
-
-
-
-
-

--- a/routes/items/itemsModel.js
+++ b/routes/items/itemsModel.js
@@ -2,25 +2,34 @@ const knex = require('knex');
 const db = require('../../data/dbConfig');
 
 module.exports = {
-    getAll,
-    getItemById,
-    updateItem,
-    deleteItem
-}
+  getAll,
+  getItemById,
+  updateItem,
+  deleteItem,
+  getItemByCategory,
+};
 
 function getAll() {
-    return db('items');
+  return db('items');
 }
 
 function getItemById(id) {
-    return db('items').where({id}).first();
+  return db('items')
+    .where({ id })
+    .first();
 }
 
 async function updateItem(id, updatedItem) {
-    const updated = await getItemById(id).update(updatedItem);
-    return updated;
+  const updated = await getItemById(id).update(updatedItem);
+  return updated;
 }
 
 function deleteItem(id) {
-    return  db('items').where({id}).delete();
+  return db('items')
+    .where({ id })
+    .delete();
+}
+
+function getItemByCategory(category) {
+  return db('items').where(category);
 }

--- a/routes/items/itemsModel.js
+++ b/routes/items/itemsModel.js
@@ -7,6 +7,9 @@ module.exports = {
   updateItem,
   deleteItem,
   getItemByCategory,
+  getItemByCondition,
+  getItemByZipCode,
+  getItemByCity,
 };
 
 function getAll() {
@@ -32,4 +35,16 @@ function deleteItem(id) {
 
 function getItemByCategory(category) {
   return db('items').where(category);
+}
+
+function getItemByCondition(condition) {
+  return db('items').where(condition);
+}
+
+function getItemByZipCode(zipcode) {
+  return db('items').where(zipcode);
+}
+
+function getItemByCity(city) {
+  return db('items').where(city);
 }

--- a/routes/items/itemsRouter.js
+++ b/routes/items/itemsRouter.js
@@ -56,4 +56,40 @@ router.post('/searchCategory', async (req, res) => {
   }
 });
 
+router.post('/searchCondition', async (req, res) => {
+  try {
+    console.log(req.body, 'just testing');
+    const condition = req.body;
+    const items = await itemsModel.getItemByCondition(condition);
+    res.status(200).json(items);
+  } catch (error) {
+    res.status(500).json({ message: 'We ran into an error' });
+    console.log(error, 'something');
+  }
+});
+
+router.post('/searchZipCode', async (req, res) => {
+  try {
+    console.log(req.body, 'just testing');
+    const zipcode = req.body;
+    const items = await itemsModel.getItemByZipCode(zipcode);
+    res.status(200).json(items);
+  } catch (error) {
+    res.status(500).json({ message: 'We ran into an error' });
+    console.log(error, 'something');
+  }
+});
+
+router.post('/searchCity', async (req, res) => {
+  try {
+    console.log(req.body, 'just testing');
+    const location = req.body;
+    const items = await itemsModel.getItemByCity(location);
+    res.status(200).json(items);
+  } catch (error) {
+    res.status(500).json({ message: 'We ran into an error' });
+    console.log(error, 'something');
+  }
+});
+
 module.exports = router;

--- a/routes/items/itemsRouter.js
+++ b/routes/items/itemsRouter.js
@@ -42,4 +42,18 @@ router.delete('/:id', async (req, res) => {
   }
 });
 
+router.post('/searchCategory', async (req, res) => {
+  try {
+    console.log(req.body, 'something somethign');
+    const category = req.body;
+    const items = await itemsModel.getItemByCategory(category);
+    console.log(category, 'aaaaaaaaaaaa');
+    console.log(items, 'bbbbbbbbbb');
+    res.status(200).json(items);
+  } catch (error) {
+    res.status(500).json({ message: 'We ran into an error' });
+    console.log(error, 'something');
+  }
+});
+
 module.exports = router;

--- a/routes/items/itemsRouter.js
+++ b/routes/items/itemsRouter.js
@@ -82,17 +82,19 @@ router.post('/searchZipCode', async (req, res) => {
 
 router.post('/searchCity', async (req, res) => {
   try {
-    console.log(req.body, 'just testing');
-    const location = req.body;
-    console.log(Object.values(location)[0]);
+    // console.log(req.body, 'just testing');
+    let location = req.body;
+    // console.log(Object.values(location)[0]);
     const cityName = Object.values(location)[0];
     const blah = cityName.substring(0, 1);
     blah.toUpperCase();
-    console.log(blah.toUpperCase());
-    console.log(typeof blah);
-    // const testString = cityName.slice(1);
+    // console.log(blah.toUpperCase());
+    // console.log(typeof blah);
+    const testString = cityName.slice(1);
     // console.log(testString);
-
+    const newString = blah.toUpperCase() + testString;
+    Object.values(location)[0] = newString;
+    location = { ...location, city: newString };
     const items = await itemsModel.getItemByCity(location);
     res.status(200).json(items);
   } catch (error) {

--- a/routes/items/itemsRouter.js
+++ b/routes/items/itemsRouter.js
@@ -84,6 +84,15 @@ router.post('/searchCity', async (req, res) => {
   try {
     console.log(req.body, 'just testing');
     const location = req.body;
+    console.log(Object.values(location)[0]);
+    const cityName = Object.values(location)[0];
+    const blah = cityName.substring(0, 1);
+    blah.toUpperCase();
+    console.log(blah.toUpperCase());
+    console.log(typeof blah);
+    // const testString = cityName.slice(1);
+    // console.log(testString);
+
     const items = await itemsModel.getItemByCity(location);
     res.status(200).json(items);
   } catch (error) {


### PR DESCRIPTION
# Description

Adds a POST /searchCategory endpoint to search items by category

example:
{
	"category": "Cameras"
}

returns a list of all items with a category of cameras
## Checklist

Remove any items which are not applicable.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works AND the tests pass
